### PR TITLE
Add leaflet support to project model

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include LICENSE.txt
 include CHANGELOG.rst
 
 recursive-include tests *
+recursive-include examples *.ipynb
+recursive-include scripts *

--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -1,0 +1,107 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interacting with projects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterfoundry.api import API\n",
+    "refresh_token = '<your refresh token>'\n",
+    "api = API(refresh_token=refresh_token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List projects\n",
+    "\n",
+    "If you have access to any projects, `api.projects` will return them as a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "projects = api.projects\n",
+    "projects"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display a project\n",
+    "\n",
+    "You can choose one of your projects with ingested scenes and add it to a leaflet map\n",
+    "in the browser."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the index in projects[3] to a value within your list of projects\n",
+    "project1 = projects[3]\n",
+    "m = project1.get_map()\n",
+    "project1.add_to(m)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare two projects\n",
+    "\n",
+    "If you have two projects with ingested scenes and in the same area, you can compare them with a slider."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the index in projects[4] to a value within your list of projects\n",
+    "project2 = projects[4]\n",
+    "m2 = project2.get_map()\n",
+    "project1.compare(project2, m2)\n",
+    "m2."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/rasterfoundry/__init__.py
+++ b/rasterfoundry/__init__.py
@@ -1,0 +1,6 @@
+# Flag to indicate whether notebook support is available
+try:
+    import ipyleaflet
+    NOTEBOOK_SUPPORT = True
+except ImportError:
+    NOTEBOOK_SUPPORT = False

--- a/rasterfoundry/__init__.py
+++ b/rasterfoundry/__init__.py
@@ -1,6 +1,6 @@
 # Flag to indicate whether notebook support is available
 try:
-    import ipyleaflet
+    import ipyleaflet  # NOQA
     NOTEBOOK_SUPPORT = True
 except ImportError:
     NOTEBOOK_SUPPORT = False

--- a/rasterfoundry/decorators.py
+++ b/rasterfoundry/decorators.py
@@ -2,6 +2,7 @@ import logging
 
 from . import NOTEBOOK_SUPPORT
 
+
 def check_notebook(f):
     def no_op():
         logging.warn('This function requires jupyter notebook and ipyleaflet')

--- a/rasterfoundry/decorators.py
+++ b/rasterfoundry/decorators.py
@@ -1,0 +1,13 @@
+import logging
+
+from . import NOTEBOOK_SUPPORT
+
+def check_notebook(f):
+    def no_op():
+        logging.warn('This function requires jupyter notebook and ipyleaflet')
+        return
+
+    if not NOTEBOOK_SUPPORT:
+        return no_op
+    else:
+        return f

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -1,10 +1,14 @@
 """A Project is a collection of zero or more scenes"""
-from ipyleaflet import (
-    Map,
-    SideBySideControl,
-    TileLayer,
-)
+from .. import NOTEBOOK_SUPPORT
 
+if NOTEBOOK_SUPPORT:
+    from ipyleaflet import (
+        Map,
+        SideBySideControl,
+        TileLayer,
+    )
+
+from ..decorators import check_notebook
 
 class Project(object):
     """A Raster Foundry project"""
@@ -28,6 +32,7 @@ class Project(object):
         self.name = project.name
         self.id = project.id
 
+    @check_notebook
     def get_map(self, **kwargs):
         """Return an ipyleaflet map centered on this project's center
 
@@ -45,6 +50,7 @@ class Project(object):
             **kwargs
         )
 
+    @check_notebook
     def add_to(self, leaflet_map):
         """Add this project to a leaflet map
 
@@ -54,6 +60,7 @@ class Project(object):
 
         leaflet_map.add_layer(self.get_layer())
 
+    @check_notebook
     def compare(self, other, leaflet_map):
         """Add a slider to compare two projects
 
@@ -83,6 +90,7 @@ class Project(object):
             center[0] = center[0] - 360
         return tuple(center)
 
+    @check_notebook
     def get_layer(self):
         """Returns a TileLayer for display using ipyleaflet"""
         return TileLayer(url=self.tms())

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -1,4 +1,9 @@
 """A Project is a collection of zero or more scenes"""
+from ipyleaflet import (
+    Map,
+    SideBySideControl,
+    TileLayer,
+)
 
 
 class Project(object):
@@ -22,6 +27,65 @@ class Project(object):
         # A few things we care about
         self.name = project.name
         self.id = project.id
+
+    def get_map(self, **kwargs):
+        """Return an ipyleaflet map centered on this project's center
+
+        Args:
+            **kwargs: additional arguments to pass to Map initializations
+        """
+        default_url = (
+            'https://cartodb-basemaps-{s}.global.ssl.fastly.net/'
+            'light_all/{z}/{x}/{y}.png'
+        )
+        return Map(
+            default_tiles=TileLayer(url=kwargs.get('url', default_url)),
+            center=self.get_center(),
+            scroll_wheel_zoom=kwargs.get('scroll_wheel_zoom', True),
+            **kwargs
+        )
+
+    def add_to(self, leaflet_map):
+        """Add this project to a leaflet map
+
+        Args:
+            leaflet_map (Map): map to add this layer to
+        """
+
+        leaflet_map.add_layer(self.get_layer())
+
+    def compare(self, other, leaflet_map):
+        """Add a slider to compare two projects
+
+        This project determines the map center.
+
+        Args:
+            other (Project): the project to compare with this project
+            leaflet_map (Map): map to add the slider to
+        """
+
+        control = SideBySideControl(
+            leftLayer=self.get_layer(), rightLayer=other.get_layer()
+        )
+        leaflet_map.add_control(control)
+
+    def get_center(self):
+        """Get the center of this project's extent"""
+        coords = self._project.extent.get('coordinates')
+        if not coords:
+            raise ValueError('Project must have coordinates to calculate a center')
+        x_min = min(coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0])
+        x_max = max(coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0])
+        y_min = min(coord[1] for coord in coords[0])
+        y_max = max(coord[1] for coord in coords[0])
+        center = [(y_min + y_max) / 2., (x_min + x_max) / 2.]
+        if center[0] > 180:
+            center[0] = center[0] - 360
+        return tuple(center)
+
+    def get_layer(self):
+        """Returns a TileLayer for display using ipyleaflet"""
+        return TileLayer(url=self.tms())
 
     def tms(self):
         """Return a TMS URL for a project"""

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -8,7 +8,8 @@ if NOTEBOOK_SUPPORT:
         TileLayer,
     )
 
-from ..decorators import check_notebook
+from ..decorators import check_notebook  # NOQA
+
 
 class Project(object):
     """A Raster Foundry project"""
@@ -80,9 +81,15 @@ class Project(object):
         """Get the center of this project's extent"""
         coords = self._project.extent.get('coordinates')
         if not coords:
-            raise ValueError('Project must have coordinates to calculate a center')
-        x_min = min(coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0])
-        x_max = max(coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0])
+            raise ValueError(
+                'Project must have coordinates to calculate a center'
+            )
+        x_min = min(
+            coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0]
+        )
+        x_max = max(
+            coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0]
+        )
         y_min = min(coord[1] for coord in coords[0])
         y_max = max(coord[1] for coord in coords[0])
         center = [(y_min + y_max) / 2., (x_min + x_max) / 2.]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# External dependencies
--e git+https://github.com/azavea/ipyleaflet.git#egg=9cfd238

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# External dependencies
+-e git+https://github.com/azavea/ipyleaflet.git#egg=9cfd238

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+# Get rid of old install maybe
+if [ -d venv ]; then
+    rm -rf venv
+fi
+
+# Reset / grab a new one
+virtualenv venv
+source venv/bin/activate
+pip install jupyter notebook
+jupyter nbextension enable --py --sys-prefix widgetsnbextension
+
+pip install -r requirements.txt
+
+jupyter nbextension install --py --symlink --sys-prefix ipyleaflet
+jupyter nbextension enable --py --sys-prefix ipyleaflet
+
+python setup.py develop

--- a/scripts/update
+++ b/scripts/update
@@ -13,7 +13,7 @@ source venv/bin/activate
 pip install jupyter notebook
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
 
-pip install -r requirements.txt
+pip install -e git+https://github.com/azavea/ipyleaflet#egg=9cfd238
 
 jupyter nbextension install --py --symlink --sys-prefix ipyleaflet
 jupyter nbextension enable --py --sys-prefix ipyleaflet

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@ universal=1
 
 [aliases]
 test=pytest
+
+[check-manifest]
+ignore=
+    examples/.ipynb_checkpoints
+    examples/.ipynb_checkpoints/*

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setuptools.setup(
         'bravado >= 8.4.0'
     ],
     extras_require={
+        'notebook': [
+            'notebook == 4.0.0'
+        ],
         'dev': [],
         'test': [],
     },

--- a/tests/test_notebook_check.py
+++ b/tests/test_notebook_check.py
@@ -1,0 +1,20 @@
+def test_warn_without_notebook_support():
+    import rasterfoundry.decorators
+    rasterfoundry.decorators.NOTEBOOK_SUPPORT = False
+    from rasterfoundry.decorators import check_notebook
+
+    @check_notebook
+    def f():
+        return 'foo'
+    assert f() is None
+
+
+def test_no_warn_with_notebook_support():
+    import rasterfoundry.decorators
+    rasterfoundry.decorators.NOTEBOOK_SUPPORT = True
+    from rasterfoundry.decorators import check_notebook
+
+    @check_notebook
+    def f():
+        return 'foo'
+    assert f() == 'foo'


### PR DESCRIPTION
Overview
------

This PR adds `get_map`, `add_to`, and `compare` methods to projects, and an example notebook showing how to use them.

Testing
------

### Functionality
- `./scripts/update`
- `source venv/bin/activate`
- `jupyter notebook`
- open `examples/Projects.ipynb` from the notebook home
- fill in your `refresh_token`, and specify `host='app.staging.rasterfoundry.com'` for `api=...`
- run the notebook, changing projects as appropriate to get projects that you actually have

### Guard against running without notebook support
- there are [tests for this](https://github.com/azavea/raster-foundry-python-client/blob/54c9e0f9b7faab89ff051043769e3b07bc69ebf2/tests/test_notebook_check.py) in the commit. Verify that they make sense.

Closes azavea/raster-foundry#1632
Closes #3