### PR TITLE
Add convenience methods to projects

### DIFF
--- a/examples/Projects.ipynb
+++ b/examples/Projects.ipynb
@@ -50,7 +50,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Change the index in projects[3] to a value within your list of projects\n",
@@ -72,14 +74,136 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Change the index in projects[4] to a value within your list of projects\n",
     "project2 = projects[4]\n",
     "m2 = project2.get_map()\n",
     "project1.compare(project2, m2)\n",
-    "m2."
+    "m2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Project export"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export as PNG"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "project = api.projects[3]\n",
+    "bbox = '-121.726057,37.278423,-121.231672,37.377250'\n",
+    "Image(project.png(bbox))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "Image(project.png(bbox, zoom=15))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export as GeoTIFF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Display in the notebook\n",
+    "\n",
+    "Note: this example requires\n",
+    "[`numpy`](http://www.numpy.org/),\n",
+    "[`matplotlib`](http://matplotlib.org/), and a fairly recent version of\n",
+    "[`rasterio`](https://mapbox.github.io/rasterio/).\n",
+    "\n",
+    "If you don't have them, you can run the cell at the bottom of this notebook,\n",
+    "provided your pip installation directory is writable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rasterio.io import MemoryFile\n",
+    "import matplotlib.pyplot as plt\n",
+    "project = api.projects[3]\n",
+    "bbox = '-121.726057,37.278423,-121.231672,37.377250'\n",
+    "data = project.geotiff(bbox, zoom=17)\n",
+    "\n",
+    "with MemoryFile(data) as memfile:\n",
+    "    with memfile.open() as dataset:\n",
+    "        plt.imshow(dataset.read(1), cmap='RdBu')\n",
+    "        \n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Save as a file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "project = api.projects[3]\n",
+    "bbox = '-121.726057,37.278423,-121.231672,37.377250'\n",
+    "data = project.geotiff(bbox, zoom=17)\n",
+    "with open('sample.tiff', 'wb') as outf:\n",
+    "    outf.write(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Installs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "pip install numpy matplotlib rasterio==1.0a8"
    ]
   }
  ],

--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -5,7 +5,7 @@ from bravado.client import SwaggerClient
 from bravado.swagger_model import load_file
 from simplejson import JSONDecodeError
 
-from models import Project
+from models import Project, MapToken
 from exceptions import RefreshTokenException
 
 
@@ -71,6 +71,29 @@ class API(object):
         except JSONDecodeError:
             raise RefreshTokenException('Error using refresh token, please '
                                         'verify it is valid')
+
+    @property
+    def map_tokens(self):
+        """List map tokens a user has access to
+
+        Returns:
+            List[MapToken]
+        """
+
+        has_next = True
+        page = 0
+        map_tokens = []
+        while has_next:
+            paginated_map_tokens = (
+                self.client.Imagery.get_map_tokens(page=page).result()
+            )
+            map_tokens += [
+                MapToken(map_token, self)
+                for map_token in paginated_map_tokens.results
+            ]
+            page = paginated_map_tokens.page + 1
+            has_next = paginated_map_tokens.hasNext
+        return map_tokens
 
     @property
     def projects(self):

--- a/rasterfoundry/models/__init__.py
+++ b/rasterfoundry/models/__init__.py
@@ -1,1 +1,2 @@
 from .project import Project  # NOQA
+from .map_token import MapToken # NOQA

--- a/rasterfoundry/models/map_token.py
+++ b/rasterfoundry/models/map_token.py
@@ -1,0 +1,23 @@
+class MapToken(object):
+    """A Raster Foundry map token"""
+
+    def __repr__(self):
+        return '<MapToken - {} - {}>'.format(self.project.name, self.token)
+
+    def __init__(self, map_token, api):
+        """Instantiate a new MapToken
+
+        Args:
+            map_token (MapToken): generated MapToken object from specification
+            api (API): api  used to make requests
+        """
+
+        self._map_token = map_token
+        self.api = api
+
+        # A few things we care about
+        self.token = map_token.id
+        self.last_modified = map_token.modifiedAt
+        self.project = [
+            proj for proj in self.api.projects if proj.id == map_token.project
+        ].pop()

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -9,6 +9,7 @@ if NOTEBOOK_SUPPORT:
     )
 
 from ..decorators import check_notebook  # NOQA
+from .map_token import MapToken
 
 
 class Project(object):
@@ -101,6 +102,19 @@ class Project(object):
     def get_layer(self):
         """Returns a TileLayer for display using ipyleaflet"""
         return TileLayer(url=self.tms())
+
+    def get_map_token(self):
+        """Returns the map token for this project
+
+        Returns:
+            str
+        """
+
+        resp = (
+            self.api.client.Imagery.get_map_tokens(projectId=self.id).result()
+        )
+        if resp.results:
+            return MapToken(resp.results[0], self.api)
 
     def tms(self):
         """Return a TMS URL for a project"""

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -1,5 +1,9 @@
 """A Project is a collection of zero or more scenes"""
+import requests
+
 from .. import NOTEBOOK_SUPPORT
+from ..decorators import check_notebook
+from .map_token import MapToken
 
 if NOTEBOOK_SUPPORT:
     from ipyleaflet import (
@@ -8,14 +12,12 @@ if NOTEBOOK_SUPPORT:
         TileLayer,
     )
 
-from ..decorators import check_notebook  # NOQA
-from .map_token import MapToken
-
 
 class Project(object):
     """A Raster Foundry project"""
 
     TILE_PATH_TEMPLATE = '/tiles/{id}/{{z}}/{{x}}/{{y}}/'
+    EXPORT_TEMPLATE = '/tiles/{project}/export/'
 
     def __repr__(self):
         return '<Project - {}>'.format(self.name)
@@ -34,22 +36,110 @@ class Project(object):
         self.name = project.name
         self.id = project.id
 
-    @check_notebook
-    def get_map(self, **kwargs):
-        """Return an ipyleaflet map centered on this project's center
+    def get_center(self):
+        """Get the center of this project's extent"""
+        coords = self._project.extent.get('coordinates')
+        if not coords:
+            raise ValueError(
+                'Project must have coordinates to calculate a center'
+            )
+        x_min = min(
+            coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0]
+        )
+        x_max = max(
+            coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0]
+        )
+        y_min = min(coord[1] for coord in coords[0])
+        y_max = max(coord[1] for coord in coords[0])
+        center = [(y_min + y_max) / 2., (x_min + x_max) / 2.]
+        if center[0] > 180:
+            center[0] = center[0] - 360
+        return tuple(center)
+
+    def get_map_token(self):
+        """Returns the map token for this project
+
+        Returns:
+            str
+        """
+
+        resp = (
+            self.api.client.Imagery.get_map_tokens(project=self.id).result()
+        )
+        if resp.results:
+            return MapToken(resp.results[0], self.api)
+
+    def get_export(self, bbox, zoom=10, export_format='png'):
+        """Download this project as a file
+
+        PNGs will be returned if the export_format is anything other than tiff
 
         Args:
-            **kwargs: additional arguments to pass to Map initializations
+            bbox (str): GeoJSON format bounding box for the download
+            export_format (str): Requested download format
+
+        Returns:
+            str
         """
-        default_url = (
-            'https://cartodb-basemaps-{s}.global.ssl.fastly.net/'
-            'light_all/{z}/{x}/{y}.png'
+
+        headers = self.api.http.session.headers.copy()
+        headers['Accept'] = 'image/{}'.format(
+            export_format
+            if export_format.lower() in ['png', 'tiff']
+            else 'png'
         )
-        return Map(
-            default_tiles=TileLayer(url=kwargs.get('url', default_url)),
-            center=self.get_center(),
-            scroll_wheel_zoom=kwargs.get('scroll_wheel_zoom', True),
-            **kwargs
+        export_path = self.EXPORT_TEMPLATE.format(project=self.id)
+        request_path = '{scheme}://{host}{export_path}'.format(
+            scheme=self.api.scheme, host=self.api.tile_host,
+            export_path=export_path
+        )
+        map_token = self.get_map_token()
+        if not map_token:
+            raise "Project {} has not yet been shared".format(self.id)
+
+        return requests.get(
+            request_path,
+            params={'bbox': bbox, 'zoom': zoom, 'mapToken': map_token.token},
+            headers=headers
+        )
+
+    def geotiff(self, bbox, zoom=10):
+        """Download this project as a geotiff
+
+        The returned string is the raw bytes of the associated geotiff.
+
+        Args:
+            bbox (str): GeoJSON format bounding box for the download
+            zoom (int): zoom level for the export
+
+        Returns:
+            str
+        """
+
+        return self.get_export(bbox, zoom, 'tiff').content
+
+    def png(self, bbox, zoom=10):
+        """Download this project as a png
+
+        The returned string is the raw bytes of the associated png.
+
+        Args:
+            bbox (str): GeoJSON format bounding box for the download
+            zoom (int): zoom level for the export
+
+        Returns
+            str
+        """
+
+        return self.get_export(bbox, zoom, 'png').content
+
+    def tms(self):
+        """Return a TMS URL for a project"""
+
+        tile_path = self.TILE_PATH_TEMPLATE.format(id=self.id)
+        return '{scheme}://{host}{tile_path}'.format(
+            scheme=self.api.scheme, host=self.api.tile_host,
+            tile_path=tile_path
         )
 
     @check_notebook
@@ -78,49 +168,25 @@ class Project(object):
         )
         leaflet_map.add_control(control)
 
-    def get_center(self):
-        """Get the center of this project's extent"""
-        coords = self._project.extent.get('coordinates')
-        if not coords:
-            raise ValueError(
-                'Project must have coordinates to calculate a center'
-            )
-        x_min = min(
-            coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0]
-        )
-        x_max = max(
-            coord[0] + (360 if coord[0] < 0 else 0) for coord in coords[0]
-        )
-        y_min = min(coord[1] for coord in coords[0])
-        y_max = max(coord[1] for coord in coords[0])
-        center = [(y_min + y_max) / 2., (x_min + x_max) / 2.]
-        if center[0] > 180:
-            center[0] = center[0] - 360
-        return tuple(center)
-
     @check_notebook
     def get_layer(self):
         """Returns a TileLayer for display using ipyleaflet"""
         return TileLayer(url=self.tms())
 
-    def get_map_token(self):
-        """Returns the map token for this project
+    @check_notebook
+    def get_map(self, **kwargs):
+        """Return an ipyleaflet map centered on this project's center
 
-        Returns:
-            str
+        Args:
+            **kwargs: additional arguments to pass to Map initializations
         """
-
-        resp = (
-            self.api.client.Imagery.get_map_tokens(projectId=self.id).result()
+        default_url = (
+            'https://cartodb-basemaps-{s}.global.ssl.fastly.net/'
+            'light_all/{z}/{x}/{y}.png'
         )
-        if resp.results:
-            return MapToken(resp.results[0], self.api)
-
-    def tms(self):
-        """Return a TMS URL for a project"""
-
-        tile_path = self.TILE_PATH_TEMPLATE.format(id=self.id)
-        return '{scheme}://{host}{tile_path}'.format(
-            scheme=self.api.scheme, host=self.api.tile_host,
-            tile_path=tile_path
+        return Map(
+            default_tiles=TileLayer(url=kwargs.get('url', default_url)),
+            center=self.get_center(),
+            scroll_wheel_zoom=kwargs.get('scroll_wheel_zoom', True),
+            **kwargs
         )

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -984,6 +984,7 @@ paths:
       tags:
         - Imagery
       parameters:
+        - $ref: '#/parameters/page'
         - $ref: '#/parameters/projectId'
         - $ref: '#/parameters/organization'
         - $ref: '#/parameters/createdBy'
@@ -1642,7 +1643,7 @@ parameters:
     type: string
     format: uuid
   projectId:
-    name: projectId
+    name: project
     in: query
     description: UUID for project
     type: string
@@ -1977,13 +1978,8 @@ definitions:
           type: string
           description: Human friendly label for map token
         project:
-          type: object
-          properties:
-            id:
-              type: string
-              format: UUID
-            name:
-              type: string
+          type: string
+          format: uuid
   MapTokenPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'

--- a/scripts/update
+++ b/scripts/update
@@ -12,8 +12,16 @@ virtualenv venv
 source venv/bin/activate
 pip install jupyter notebook
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
-
 pip install -e git+https://github.com/azavea/ipyleaflet#egg=9cfd238
+
+# MacOS has some sort of messy openSSL incompatibility
+# See https://github.com/pyca/cryptography/issues/3489
+if [ "$(uname -s)" == "Darwin" ]; then
+    pip install cryptography \
+        --global-option=build_ext \
+        --global-option="-L/usr/local/opt/openssl/lib" \
+        --global-option="-I/usr/local/opt/openssl/include"
+fi
 
 jupyter nbextension install --py --symlink --sys-prefix ipyleaflet
 jupyter nbextension enable --py --sys-prefix ipyleaflet

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['tests']),
     package_data={'': ['*.yml']},
     install_requires=[
-        'cryptography >= 1.3.2',
+        'cryptography == 1.8.1',
         'pyasn1 >= 0.2.3',
         'requests >= 2.9.1',
         'bravado >= 8.4.0'


### PR DESCRIPTION
Overview
------

This PR adds convenience methods to `Project`s for fetching map tokens and for downloading PNGs and geotiffs.

Notes
------

There are changes to the swagger spec that need to be propagated back to the main repository. I'll put up another PR for those changes momentarily.

Testing
------

- `./scripts/update`
- `source venv/bin/activate(.fish)`
- `pip install numpy matplotlib rasterio==1.0a8` (since these aren't project dependencies, but you'll need them to run one of the cells in the notebook)
- `jupyter notebook`
- open `examples/Projects.ipynb`
- set `host=app.staging.rasterfoundry.com` in `api=...`
- run the first two cells, then skip down to the export section
- pick a project you've shared previously with ingested scenes
- Run the cells in the export section

Closes azavea/raster-foundry#1633
Closes azavea/raster-foundry#1634