### PR TITLE
Fix install for Mac OS

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -14,16 +14,7 @@ pip install jupyter notebook
 jupyter nbextension enable --py --sys-prefix widgetsnbextension
 pip install -e git+https://github.com/azavea/ipyleaflet#egg=9cfd238
 
-# MacOS has some sort of messy openSSL incompatibility
-# See https://github.com/pyca/cryptography/issues/3489
-if [ "$(uname -s)" == "Darwin" ]; then
-    pip install cryptography \
-        --global-option=build_ext \
-        --global-option="-L/usr/local/opt/openssl/lib" \
-        --global-option="-I/usr/local/opt/openssl/include"
-fi
-
 jupyter nbextension install --py --symlink --sys-prefix ipyleaflet
 jupyter nbextension enable --py --sys-prefix ipyleaflet
 
-python setup.py develop
+pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     ],
     extras_require={
         'notebook': [
-            'notebook == 4.0.0'
+            'notebook >= 4.0.0'
         ],
         'dev': [],
         'test': [],


### PR DESCRIPTION
Overview
------

This PR makes it so that `./scripts/update` works the same on Mac as it does on Linux.
For some reason, `setup.py develop` fails to install `cryptography`, while `pip install -e .`,
which _runs `setup.py develop` as its last step_, succeeds.

Also it relaxed the notebook dependency, since apparently `ipyleaflet` installs 5.0.0 right
now, and paying the cost to install `notebook` twice is a draaaaaag.

Testing
------

- be on a Mac
- run `./scripts/update`
- observe success

Fixes #5 