### PR TITLE
Include token with api request

### DIFF
--- a/rasterfoundry/api.py
+++ b/rasterfoundry/api.py
@@ -49,6 +49,7 @@ class API(object):
         elif not api_token:
             raise Exception('Must provide either a refresh token or API token')
 
+        self.api_token = api_token
         self.http.session.headers['Authorization'] = 'Bearer {}'.format(
             api_token)
 

--- a/rasterfoundry/models/project.py
+++ b/rasterfoundry/models/project.py
@@ -137,10 +137,11 @@ class Project(object):
         """Return a TMS URL for a project"""
 
         tile_path = self.TILE_PATH_TEMPLATE.format(id=self.id)
-        return '{scheme}://{host}{tile_path}'.format(
+        path = '{scheme}://{host}{tile_path}'.format(
             scheme=self.api.scheme, host=self.api.tile_host,
             tile_path=tile_path
         )
+        return path + '?token={}'.format(self.api.api_token)
 
     @check_notebook
     def add_to(self, leaflet_map):


### PR DESCRIPTION
@rossbernet, @tgilcrest, and @jmorrison1847 are starting to use the client for demo prep. This enables them to create non-public projects for demo purposes while still being able to show the projects in the notebook.

Trivial, merging.