### PR TITLE
Add scenes post body parameters

### DIFF
--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -1,12 +1,13 @@
 swagger: '2.0'
 info:
   title: Raster Foundry
-  description: An application to find and manipulate large-scale geospatial and raster data
+  description: An application to find, view, and analyze geospatial data at any scale
   version: "0.1.0"
 
-host: app.rasterfoundry.com
+host: localhost:9000
 
 schemes:
+  - http
   - https
 
 basePath: /api
@@ -20,64 +21,67 @@ x-top-matter:
   - title: Introduction
     level: 1
     content: |
-      This document describes the Raster Foundry API, which is meant to by used by user facing frontends or backend-servers.
-      Generally speaking, all user facing functions are available on the default frontend unless specified otherwise.
-  - title: Using the API
+      The Raster Foundry API allows developers to find, view, and analyze geospatial data in Raster Foundry. As the name implies, it's especially useful for working with large raster datasets like satellite imagery.
+
+      Raster Foundry is built with an openly licensed, open source code base. If you'd like to peek under the hood, make a request, or become a contributor, <a href="https://github.com/azavea/raster-foundry/issues" target="_blank">find us on Github</a>.
+  - title: Authentication
     level: 2
     content: |
-      For testing purposes, our API can be queried using tools such as <a href="https://curl.haxx.se/">cURL</a>, <a href="https://www.getpostman.com/">Postman</a>, or <a href="https://advancedrestclient.com/">Advanced Rest Client</a>
+      Our API identifies applications and users with <a href="https://jwt.io/introduction/" target="_blank">JSON Web Tokens (JWT)</a>. Refresh tokens can be created in your Raster Foundry account and used to generate example requests signed with valid session tokens <a href="https://help.rasterfoundry.com/developer-resources/generating-a-refresh-token-in-order-to-use-the-api" target="_blank">(detailed instructions are available here)</a>.
 
 x-resources:
   - name: Projects
     description: |
-      Projects are composed of scenes, and are the unit which Tools act on
+      Projects are user-defined collections of scenes and are the fundamental unit that tools act on.
     further-description:
       - title: Project permissions
         content: |
-          Projects can be shared publicly, with your organzation, or privately by link only.
-          Currently, only private projects are supported.
-
+          Projects are currently private to the user that created them and cannot be discovered by other Raster Foundry users. However, projects can be shared publicly as a tiled web map with a direct link.
+          Project permissions will eventually expand to include making projects discoverable to all users or just users within an organization.
   - name: Scenes
     description: |
-      Scenes are sets of images which are viewed and color corrected as a unit
+      Scenes are single or multi-image rasters where every image within the scene shares the same metadata characteristics and are always associated with a datasource. This simplest example of a scene is a single-band image like a land classification raster. The most complex example is a multi-image scene made up of multi-band images, like a pre-tiled aerial image where each tile is one piece of a larger coherent scene.
     further-description:
       - title: Scene permissions
         content: |
-          Scenes can be shared publicly, with your organzation, or privately.
-          All user uploaded Scenes are by default private, and Scenes generated from publicly available data are public.
-
+          By default, imported scenes are private to the user that uploaded them and scenes generated from public data sources are discoverable by all users.
+          Scene permissions will eventually expand to include making imported scenes discoverable to all users or just users within an organization.
   - name: Images
     description: |
-      A single image, with 1 or more bands
+      Images are single or multi-band rasters that can be viewed and edited as a single unit but are always associated with a parent scene. They are sometimes synonymous with their parent scenes and other times just one of several images associated with their parent scenes. One common example of an image is a multispectral satellite image; another is a land classification raster.
     further-description:
       - title: Image permissions
         content: |
-          Images can be shared publicly, with your organzation, or privately.
-          All user uploaded Images are by default private, and Images generated from publicly available data are public.
+          Images respect the permissions applied to their parent scenes.
   - name: Uploads
-    description: User uploads
+    description: Uploads are datasets that a user or application has attempted to upload to Raster Foundry (successfully or unsuccessfully).
     further-description:
-      - title: Image permissions
+      - title: Uploads permissions
         content: |
-          All user uploads are private
+          All user uploads are private to that user.
   - name: Datasources
     description: |
-      Datasources contain information common to all images uploaded through them such as composites and default color corrections
+      "Datasources contain information common to all scenes associated with them, such as the number of bands to expect in images associated with that datasource. A datasource can be specific (e.g. a particular earth observation satellite) or generic (e.g. a 3-band sensor on a UAV). All scenes must have an associated datasource."
+
+      "Currently, datasources cannot be created through the API and must be requested (<a href="https://github.com/azavea/raster-foundry/issues" target="_blank">preferably as a Github issue in the source repository</a>)."
+
+      "In the future, users will be able to manage the creation, amendment, and deletion of datasources directly through the API. Also, users will be able to assign transformations like color correction, band composites, or color maps to datasources as a default for themselves and/or their organizations."
   - name: Tokens
     description: |
-      Tokens are used to access the API, either through a frontend or an api client.
+      Tokens are used to securely identify users and applications accessing the API.
   - name: Tools
     description: |
-      Tools are used to apply transformations to Rasters
+      Tools are algorithms that can be applied to projects manually or automatically.
+      Tools can range from primitive statistical queries, to algebraic functions, to complex logic trees of operations happening in parallel. Tools can be constructed of other tools, custom-defined operations, or both. They can take any number of projects as inputs.
   - name: Users
     description: |
-      User management functions
+      Users and third party applications can be managed with the Users resource.
   - name: Organizations
     description: |
-      Organization management functions
+      Organizations are associations of users who share uniform access to permissions-protected resources.
   - name: Exports
     description: |
-      View and manage project Exports
+      Projects can be exported, but individual scenes and images cannot.
 
 tags:
   - name: Users
@@ -97,7 +101,7 @@ paths:
     get:
       summary: Get a list of users
       description: |
-        The Users API endpoint enables searching and listing users.
+        Search for and list users by different characteristics
       tags:
         - Users
       parameters:
@@ -131,10 +135,24 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+  /users/dropbox-setup/:
+    x-resource: Users
+    post:
+      summary: Store a dropbox access token for a user from an authorization code
+      tags:
+        - Users
+      parameters:
+          - name: DropboxAuthRequest
+            in: body
+            schema:
+              $ref: '#/definitions/DropboxAuthRequest'
+      responses:
+        200:
+          description: Dropbox access token successfully fetched
   /users/me/:
     x-resource: Users
     get:
-      summary: Get logged in user profile
+      summary: Get a logged-in user profile
       tags:
         - Users
       responses:
@@ -206,7 +224,7 @@ paths:
   /organizations/:
     x-resource: Organizations
     get:
-      summary: Retrieve list of organizations
+      summary: Get a list of organizations
       tags:
         - Users
       parameters:
@@ -219,7 +237,7 @@ paths:
           schema:
             $ref: '#/definitions/OrganizationPaginated'
     post:
-      summary: Create a new organization
+      summary: Create an organization
       tags:
         - Users
       parameters:
@@ -230,7 +248,7 @@ paths:
             $ref: '#/definitions/Organization'
       responses:
         201:
-          description: Return newly created organization
+          description: Get newly created organization
           schema:
             $ref: '#/definitions/Organization'
         default:
@@ -240,7 +258,7 @@ paths:
   /organizations/{organizationId}/:
     x-resource: Organizations
     get:
-      summary: Retrieve details for an organization
+      summary: Get details for an organization
       tags:
         - Users
       parameters:
@@ -281,7 +299,7 @@ paths:
   /organizations/{organizationId}/users/:
     x-resource: Organizations
     get:
-      summary: Get a list of users and their roles for the specified organization
+      summary: Get users and roles for an organization
       tags:
         - Users
       parameters:
@@ -302,13 +320,14 @@ paths:
   /datasources/:
     x-resource: Datasources
     get:
-      summary: Lists paginated datasources that a user has access to
+      summary: Get a list of datasources
       description: |
         Datasources are sensors that share common metadata, like default color corrections. Scenes from
         a given datasource can be mosaiced and color corrected together.
       tags:
         - Datasources
       parameters:
+        - $ref: '#/parameters/owner'
         - $ref: '#/parameters/name'
       # TODO: fill in all possible responses
       responses:
@@ -329,6 +348,7 @@ paths:
         - $ref: '#/parameters/organization'
         - $ref: '#/parameters/datasource'
         - $ref: '#/parameters/uploadStatus'
+        - $ref: '#/parameters/owner'
       responses:
         200:
           description: Paginated list of uploads
@@ -361,7 +381,7 @@ paths:
   /uploads/{uuid}/:
     x-resource: Uploads
     get:
-      summary: Retrieve upload details
+      summary: Get upload details
       tags:
         - Imagery
       parameters:
@@ -378,15 +398,16 @@ paths:
             $ref: '#/definitions/Error'
     put:
       summary: Update an upload
+      description: Update an existing upload
       tags:
         - Imagery
       parameters:
+        - $ref: '#/parameters/uuid'
         - name: upload
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Upload'
-        - $ref: '#/parameters/uuid'
+            $ref: '#/definitions/UploadCreate'
       responses:
         204:
           description: Update successful (no further processing needed)
@@ -416,7 +437,7 @@ paths:
   /uploads/{uuid}/credentials/:
     x-resource: Uploads
     get:
-      summary: Get credentials scoped to this uploads bucket. If this is not a local upload
+      summary: Get credentials for an AWS S3 bucket
       tags:
         - Authentication
         - Imagery
@@ -437,15 +458,12 @@ paths:
   /scenes/:
     x-resource: Scenes
     get:
-      summary: Lists paginated scenes that a user has access to
-      description: |
-        Scenes are groups of images that share metadata and would typically be viewed together on a map.
-        They are ingested into Raster RDDs by GeoTrellis and are able to be added to projects, mosaiced,
-        and have other operations performed on them.
+      summary: Get a list of scenes
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/orderingScene'
+        - $ref: '#/parameters/owner'
         - $ref: '#/parameters/pageSize'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/organization'
@@ -476,9 +494,15 @@ paths:
           schema:
             $ref: '#/definitions/ScenePaginated'
     post:
-      summary: Create a new scene
+      summary: Create a scene
       tags:
         - Imagery
+      parameters:
+        - name: scene
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Scene'
       responses:
         201:
           description: Successfully created a new scene
@@ -491,7 +515,7 @@ paths:
   /scenes/{uuid}/:
     x-resource: Scenes
     get:
-      summary: Retrieve scene details
+      summary: Get scene details
       tags:
         - Imagery
       parameters:
@@ -530,7 +554,10 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a scene (Warning will delete any associated imagery)
+      summary: Delete a scene
+      description: |
+        Warning: this will delete any associated imagery as well.
+
       tags:
         - Imagery
       parameters:
@@ -546,7 +573,7 @@ paths:
   /scene-grid/{zoom}/{column}/{row}/:
     x-resource: Scenes
     get:
-      summary: Scene statistics for a tile
+      summary: Get scene statistics for a tile
       tags:
         - Statistics
       parameters:
@@ -572,6 +599,7 @@ paths:
         - $ref: '#/parameters/maxResolution'
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/ingested'
+        - $ref: '#/parameters/ingestStatus'
       responses:
         200:
           description: Statistics for the given bounding box
@@ -584,13 +612,16 @@ paths:
   /projects/:
     x-resource: Projects
     get:
-      summary: Get list of projects the user is authorized to view
+      summary: Get a list of projects
+      description:  |
+        Only projects that the user has permission to view will be returned.
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/orderingBase'
         - $ref: '#/parameters/pageSize'
         - $ref: '#/parameters/page'
+        - $ref: '#/parameters/owner'
         - $ref: '#/parameters/organization'
         - $ref: '#/parameters/tags'
       responses:
@@ -599,7 +630,7 @@ paths:
           schema:
             $ref: '#/definitions/ProjectPaginated'
     post:
-      summary: Create a new project
+      summary: Create a project
       tags:
         - Imagery
       parameters:
@@ -616,7 +647,7 @@ paths:
   /projects/{uuid}/:
     x-resource: Projects
     get:
-      summary: Retrieve project details
+      summary: Get project details
       tags:
         - Imagery
       parameters:
@@ -669,8 +700,9 @@ paths:
             $ref: '#/definitions/Error'
 
   /projects/{uuid}/areas-of-interest/:
+    x-resource: Projects
     get:
-      summary: Get all Areas of Interest for this project.
+      summary: Get all areas of interest for a project
       tags:
         - Imagery
       parameters:
@@ -684,7 +716,7 @@ paths:
             $ref: '#/definitions/AoiPaginated'
 
     post:
-      summary: Create an Area of Interest for this project.
+      summary: Create an area of interest for a project
       tags:
         - Imagery
       parameters:
@@ -707,7 +739,7 @@ paths:
   /projects/{uuid}/scenes/:
     x-resource: Projects
     get:
-      summary: Get a list of scenes associated with this project
+      summary: Get a list of scenes associated with a project
       tags:
         - Imagery
       parameters:
@@ -735,13 +767,14 @@ paths:
         - $ref: '#/parameters/tags'
         - $ref: '#/parameters/ingested'
         - $ref: '#/parameters/ingestStatus'
+        - $ref: '#/parameters/pending'
       responses:
         200:
           description: Paginated list of scenes associated with this project
           schema:
             $ref: '#/definitions/ScenePaginated'
     post:
-      summary: Create a new association between a set of scenes and this project
+      summary: Add scenes to a project by their ID
       tags:
         - Imagery
       parameters:
@@ -763,7 +796,7 @@ paths:
             items:
               $ref: '#/definitions/Scene'
     put:
-      summary: Replace the set of scenes in a project
+      summary: Replace scenes in a project
       tags:
         - Imagery
       parameters:
@@ -781,7 +814,7 @@ paths:
         204:
           description: No content, update successful
     delete:
-      summary: Delete a set of scenes from a project
+      summary: Delete scenes from a project
       tags:
         - Imagery
       parameters:
@@ -801,7 +834,7 @@ paths:
 
   /projects/{uuid}/scenes/{uuid2}/accept:
     post:
-      summary: Approve a pending Scene which passed an AOI check.
+      summary: Approve a pending scene which has passed an area of interest check.
       tags:
         - Imagery
       parameters:
@@ -811,10 +844,28 @@ paths:
         204:
           description: Successfully accepted the Scene.
 
+  /projects/{uuid}/scenes/accept:
+    post:
+      summary: Approve a list of pending scenes which have passed an area of interest check.
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: scenes
+          in: body
+          required: true
+          description: UUIDs of scenes to approve
+          schema:
+            $ref: '#/definitions/BulkAcceptParams'
+      responses:
+        204:
+          description: Successfully accepted scenes
+
+
   /projects/{uuid}/scenes/bulk-add-from-query/:
     x-resource: Projects
     post:
-      summary: Create a new association between a set of scenes and this project
+      summary: Add scenes to a project based on search parameters
       tags:
         - Imagery
       parameters:
@@ -835,7 +886,7 @@ paths:
   /projects/{uuid}/mosaic/:
     x-resource: Projects
     get:
-      summary: List of a project\'s scene IDs and their associated color correction parameters to be used in mosaicing
+      summary: "Get a list of a project's scene IDs and their color-correction parameters"
       tags:
         - Imagery
       parameters:
@@ -849,7 +900,7 @@ paths:
   /projects/{uuid}/mosaic/bulk-update-color-corrections/:
     x-resource: Projects
     post:
-      summary: Persist a batch of project/scene pairing\'s color correction parameters
+      summary: Save color-correction parameters for all scenes in a project
       tags:
         - Imagery
       parameters:
@@ -862,10 +913,11 @@ paths:
       responses:
         200:
           description: "Successfully updated all scenes' color correction parameters"
+
   /projects/{uuid}/mosaic/{uuid2}:
     x-resource: Projects
     get:
-      summary: A project/scene pairing\'s persisted color correction parameters
+      summary: "Get a project's saved color-correction parameters"
       tags:
         - Imagery
       parameters:
@@ -877,7 +929,7 @@ paths:
           schema:
             $ref: '#/definitions/ColorCorrection'
     put:
-      summary: Associate posted color correction parameters with a project/scene pairing
+      summary: Save color-correction parameters for a particular scene
       tags:
         - Imagery
       parameters:
@@ -894,7 +946,7 @@ paths:
   /projects/{uuid}/order:
     x-resource: Projects
     get:
-      summary: An ordered list of scene IDs belonging to the specified project
+      summary: Get a list of scene IDs belonging to a project
       tags:
         - Imagery
       parameters:
@@ -904,7 +956,7 @@ paths:
         200:
           description: Order of scenes in project for mosaic purposes
     put:
-      summary: Create/update an ordering among scenes within the specified project
+      summary: Set a z-index order for scenes within the specified project
       tags:
         - Imagery
       parameters:
@@ -916,13 +968,14 @@ paths:
 
   /areas-of-interest/:
     get:
-      summary: Get all AOIs the user is authorized to view.
+      summary: Get a list of areas of interest
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/pageSize'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/organization'
+        - $ref: '#/parameters/owner'
       responses:
         200:
           description: A paginated list of all AOIs the user is authorized to view.
@@ -931,7 +984,7 @@ paths:
 
   /areas-of-interest/{uuid}/:
     get:
-      summary: Get a requested Area of Interest.
+      summary: Get a specific area of interest
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -940,7 +993,7 @@ paths:
           schema:
             $ref: '#/definitions/AOI'
     put:
-      summary: Update an Area of Interest.
+      summary: Update an area of interest
       tags:
         - Imagery
       parameters:
@@ -962,7 +1015,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a project.
+      summary: Delete a project
       tags:
         - Imagery
       parameters:
@@ -980,11 +1033,10 @@ paths:
     get:
       summary: Get a list of map tokens
       description: |
-        Lists map tokens, automatically filtered by a user
+        Map tokens are filtered by user
       tags:
         - Imagery
       parameters:
-        - $ref: '#/parameters/page'
         - $ref: '#/parameters/projectId'
         - $ref: '#/parameters/organization'
         - $ref: '#/parameters/createdBy'
@@ -998,7 +1050,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create a new map token
+      summary: Create a map token
       tags:
         - Imagery
       parameters:
@@ -1018,7 +1070,7 @@ paths:
   /map-tokens/{uuid}/:
     x-resource: Tokens
     get:
-      summary: Retrieve map token details
+      summary: Get map token details
       tags:
         - Imagery
       parameters:
@@ -1073,7 +1125,7 @@ paths:
   /images/:
     x-resource: Images
     get:
-      summary: Paginated list of project images
+      summary: Get a list of images in a project
       tags:
         - Imagery
       parameters:
@@ -1085,13 +1137,16 @@ paths:
         - $ref: '#/parameters/maxRawDataBytes'
         - $ref: '#/parameters/minResolution'
         - $ref: '#/parameters/maxResolution'
+        - $ref: '#/parameters/owner'
       responses:
         200:
           description: Paginated list of images
           schema:
             $ref: '#/definitions/ImagePaginated'
     post:
-      summary: Create a new image not associated with any Project
+      summary: Create an image
+      description:  |
+        You must associate an image with a scene, either one you create for that image or an existing one that you are adding the newly created image to.
       tags:
         - Imagery
       parameters:
@@ -1108,7 +1163,7 @@ paths:
   /images/{uuid}:
     x-resource: Images
     get:
-      summary: Details of a Image
+      summary: Get the details of an image
       tags:
         - Imagery
       parameters:
@@ -1123,7 +1178,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a Image
+      summary: Update an image
       tags:
         - Imagery
       parameters:
@@ -1149,7 +1204,7 @@ paths:
   /thumbnails/:
     x-resource: Scenes
     get:
-      summary: Paginated list of thumbnails
+      summary: Get a list of thumbnails
       tags:
         - Imagery
       parameters:
@@ -1165,7 +1220,7 @@ paths:
   /thumbnails/{uuid}/:
     x-resource: Scenes
     get:
-      summary: Thumbnail details
+      summary: Get thumbnail details
       tags:
         - Imagery
       parameters:
@@ -1183,8 +1238,9 @@ paths:
     x-resource: Tokens
     get:
       summary: |
-        Retrieve a list of refresh token summaries. Note: Only names and identifiers are revealed,
-        refresh tokens themselves are only revealed once, when created for security purposes.
+        Get a list of refresh token summaries
+      description: |
+        Note: Only names and identifiers are revealed. Refresh tokens themselves are only revealed once (when they are created) for security purposes.
       tags:
         - Authentication
       responses:
@@ -1200,7 +1256,7 @@ paths:
             $ref: '#/definitions/Error'
     post:
       summary: |
-        Request a new JSON web token to use in requests using a refresh token
+        Request a new refresh token
       parameters:
         - name: refreshToken
           in: body
@@ -1238,12 +1294,13 @@ paths:
   /tools/:
     x-resource: Tools
     get:
-      summary: Lists tools that perform a set of geoprocessing/map algebra functions
+      summary: Get a list of tools
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/orderingBase'
         - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/owner'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/minRating'
         - $ref: '#/parameters/maxRating'
@@ -1260,7 +1317,7 @@ paths:
         default:
           description: Error message if insufficient permissions
     post:
-      summary: Create a new geoprocessing tool
+      summary: Create a tool
       tags:
         - Lab
       responses:
@@ -1273,7 +1330,7 @@ paths:
   /tools/{uuid}/:
     x-resource: Tools
     get:
-      summary: Retrieve details for a single geoprocessing tool
+      summary: Get details for a particular tool
       tags:
         - Lab
       parameters:
@@ -1297,7 +1354,7 @@ paths:
         default:
           description: Delete unsuccessful, either object did not exist or insufficient permissions
     put:
-      summary: Update a geoprocessing tool
+      summary: Update a tool
       tags:
         - Lab
       parameters:
@@ -1310,11 +1367,12 @@ paths:
   /tool-tags/:
     x-resource: Tools
     get:
-      summary: List tool tags
+      summary: Get a list of tool tags
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/search'
+        - $ref: '#/parameters/owner'
       responses:
         200:
           description: Retrieve a paginated list of tool tags
@@ -1336,7 +1394,7 @@ paths:
   /tool-tags/{uuid}/:
     x-resource: Tools
     get:
-      summary: Get detail of a tool tag
+      summary: Get the details of a tool tag
       tags:
         - Lab
       parameters:
@@ -1349,7 +1407,7 @@ paths:
         404:
           description: Error message if insufficient permissions or tag does not exist
     delete:
-      summary: Delete a given tag
+      summary: Delete a tool tag
       tags:
         - Lab
       parameters:
@@ -1360,7 +1418,7 @@ paths:
         default:
           description: Error message if insufficient permissions to delete a tag
     put:
-      summary: Update a given tool tag
+      summary: Update a tool tag
       tags:
         - Lab
       parameters:
@@ -1373,7 +1431,7 @@ paths:
   /tool-categories/:
     x-resource: Tools
     get:
-      summary: Retrieve list of tool categories
+      summary: Get a list of tool categories
       parameters:
         - $ref: '#/parameters/search'
       tags:
@@ -1384,7 +1442,7 @@ paths:
           schema:
             $ref: '#/definitions/ToolCategoryPaginated'
     post:
-      summary: Create a new tool category
+      summary: Create a tool category
       tags:
         - Lab
       responses:
@@ -1395,7 +1453,7 @@ paths:
   /tool-categories/{slugLabel}/:
     x-resource: Tools
     get:
-      summary: Retrieve details of a tool category
+      summary: Get the details of a tool category
       tags:
         - Lab
       parameters:
@@ -1426,12 +1484,15 @@ paths:
   /tool-runs/:
     x-resource: Tools
     get:
-      summary: Retrieve a list of tool runs
+      summary: Get a list of tool runs
+      description: |
+        A tool run is a specific implementation of a tool. Tool runs can specify inputs and parameters neccessary to execute a tool.
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/project'
         - $ref: '#/parameters/tool'
+        - $ref: '#/parameters/owner'
         - $ref: '#/parameters/createdBy'
       responses:
         200:
@@ -1439,7 +1500,7 @@ paths:
           schema:
             $ref: '#/definitions/ToolRunPaginated'
     post:
-      summary: Create a new tool run
+      summary: Create a tool run
       tags:
         - Lab
       responses:
@@ -1452,7 +1513,7 @@ paths:
   /tool-runs/{uuid}/:
     x-resource: Tools
     get:
-      summary: Retrieve details about a tool run
+      summary: Get details about a tool run
       tags:
         - Lab
       parameters:
@@ -1496,8 +1557,6 @@ paths:
     x-resource: Exports
     get:
       summary: Get a list of exports
-      description: |
-        The exprots API endpoint enables searching, listing, and creating new exports.
       tags:
         - Imagery
       parameters:
@@ -1506,6 +1565,7 @@ paths:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/organization'
         - $ref: '#/parameters/project'
+        - $ref: '#/parameters/owner'
         - $ref: '#/parameters/exportStatus'
       responses:
         200:
@@ -1539,7 +1599,7 @@ paths:
   /exports/{uuid}/:
     x-resource: Exports
     get:
-      summary: Retrieve export details
+      summary: Get export details
       tags:
         - Imagery
       parameters:
@@ -1594,7 +1654,7 @@ paths:
   /exports/{uuid}/definition:
     x-resource: Exports
     get:
-      summary: Retrieve export details
+      summary: Get export details
       tags:
         - Imagery
       parameters:
@@ -1609,13 +1669,59 @@ paths:
             UUID parameter does not refer to an export or the user is not able to view the export it refers to
           schema:
             $ref: '#/definitions/Error'
+  /exports/{uuid}/files:
+    x-resource: Exports
+    get:
+      summary: Get available files for the export
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: List of files within an export
+          schema:
+            type: "array"
+            items:
+              type: "string"
+        404:
+          description: |
+            UUID parameter does not refer to an export or the user is not able to view the export it refers to or export was not finished successfully yet.
+          schema:
+            $ref: '#/definitions/Error'
+  /exports/{uuid}/files/{filename}:
+    x-resource: Exports
+    get:
+      summary: Download a file from an export
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: filename
+          required: true
+          in: path
+          type: string
+          description: The filename of the file the user wishes to download. Filenames of an export need to first be fetched.
+      responses:
+        200:
+          description: The content of the reqested file
+          schema:
+            type: file
+        404:
+          description: |
+            UUID does not reference an export that exists, the user has access to, and has finished successfully. The filename may not exist
+          schema:
+            $ref: '#/definitions/Error'
+        503:
+          description: The request rate has been exceeded.
+          schema:
+            $ref: '#/definitions/Error'
 
 parameters:
-
   orderingBase:
     name: ordering
     in: query
-    description: Field to order results by; meaning of label varies based on tool
+    description: Field to order results; meaning of label varies based on endpoint
     type: array
     collectionFormat: pipes
     items:
@@ -1643,7 +1749,7 @@ parameters:
     type: string
     format: uuid
   projectId:
-    name: project
+    name: projectId
     in: query
     description: UUID for project
     type: string
@@ -1903,7 +2009,7 @@ parameters:
     required: true
   bbox:
     name: bbox
-    description: Bounding box. eg "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat". Delimit multiple with semicolon.
+    description: Bounding box of the form "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat". Delimit multiple with semicolons.
     in: query
     type: string
     required: false
@@ -1926,16 +2032,28 @@ parameters:
     in: query
     type: string
     required: false
+  pending:
+    name: pending
+    description: "Filter by scene's acceptance for an AOI project"
+    in: query
+    type: boolean
+    required: false
   tool:
     name: toolId
-    description: Filter by tool\'s slug label
+    description: "Filter by tool's slug label"
     in: query
     type: string
     format: uuid
     required: false
   createdBy:
     name: createdBy
-    description: Filter by creator\'s slug label
+    description: Filter by creator
+    in: query
+    type: string
+    required: false
+  owner:
+    name: owner
+    description: Filter by object owner
     in: query
     type: string
     required: false
@@ -1967,6 +2085,12 @@ definitions:
       organizationId:
         type: string
         description: uuid for organization
+  BaseCreate:
+    type: object
+    properties:
+      owner:
+        type: string
+        description: Optional during object creation, owner of an object
   MapToken:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -1978,8 +2102,13 @@ definitions:
           type: string
           description: Human friendly label for map token
         project:
-          type: string
-          format: uuid
+          type: object
+          properties:
+            id:
+              type: string
+              format: UUID
+            name:
+              type: string
   MapTokenPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -1997,6 +2126,13 @@ definitions:
         format: uuid
       colorCorrection:
         $ref: '#/definitions/ColorCorrection'
+  DropboxAuthRequest:
+    type: object
+    properties:
+      authorizationCode:
+        type: string
+      redirectURI:
+        type: string
   AOI:
     type: object
     properties:
@@ -2010,12 +2146,6 @@ definitions:
   ColorCorrection:
     type: object
     properties:
-      alpha:
-        type: number
-        format: float
-      beta:
-        type: number
-        format: float
       redBand:
         type: number
         format: integer
@@ -2025,29 +2155,83 @@ definitions:
       blueBand:
         type: number
         format: integer
-      redGamma:
-        type: number
-        format: float
-      greenGamma:
-        type: number
-        format: float
-      blueGamma:
-        type: number
-        format: float
-      brightness:
-        type: number
-        format: float
-      min:
-        type: number
-        format: float
-      max:
-        type: number
-        format: float
+      sigmoidalContrast:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+          alpha:
+            type: number
+            format: float
+          beta:
+            type: number
+            format: float
+      gamma:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+          redGamma:
+            type: number
+            format: float
+          greenGamma:
+            type: number
+            format: float
+          blueGamma:
+            type: number
+            format: float
+      bandClipping:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+          redMax:
+            type: number
+            format: int
+          redMin:
+            type: number
+            format: int
+          greenMax:
+            type: number
+            format: int
+          greenMin:
+            type: number
+            format: int
+          blueMax:
+            type: number
+            format: int
+          blueMin:
+            type: number
+            format: int
+      tileClipping:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+          min:
+            type: number
+            format: int
+          max:
+            type: number
+            format: int
+      saturation:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+          saturation:
+            type: number
+            format: float
       equalize:
-        type: boolean
-      contrast:
-        type: number
-        format: float
+        type: object
+        properties:
+          enabled:
+            type: boolean
+      autoBalance:
+        type: object
+        properties:
+          enabled:
+            type: boolean
 
   TimeModelMixin:
     type: object
@@ -2063,16 +2247,19 @@ definitions:
         format: date-time
   UserTrackingMixin:
     type: object
-    readOnly: true
     properties:
       createdBy:
         type: string
-        format: uuid
-        description: UUID of user who created the Object
+        description: User who created the object
+        readOnly: true
       modifiedBy:
         type: string
-        format: uuid
-        description: UUID of user who most recently modified the object
+        description: User who most recently modified the object
+        readOnly: true
+      owner:
+        type: string
+        description: User who owns the object
+
   User:
     allOf:
     - $ref: '#/definitions/TimeModelMixin'
@@ -2096,6 +2283,12 @@ definitions:
             - USER
             - VIEWER
             - OWNER
+        dropboxCredential:
+          type: string
+          description: Contains the user's dropbox credential if a connection has been configured
+        planetCredential:
+          type: string
+          description: Contains the user's planet credential if a connection has been configured
   UserWithOAuth:
     type: object
     properties:
@@ -2419,6 +2612,9 @@ definitions:
         manualOrder:
           type: boolean
           description: Is true if project scenes are manually ordered
+        isAOIProject:
+          type: boolean
+          description: Is true if project is an area-of-interest project
   Image:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -2443,6 +2639,7 @@ definitions:
           description: URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.
         rawDataBytes:
           type: integer
+          format: int64
           description: Size of original uploaded imagery in bytes
         bands:
           type: array
@@ -2704,6 +2901,8 @@ definitions:
         type: string
       modifiedBy:
         type: string
+      owner:
+        type: string
 
   TimestampParams:
     type: object
@@ -2723,47 +2922,60 @@ definitions:
         format: datetime
   UploadCreate:
     type: object
-    properties:
-      uploadStatus:
-        type: string
-        description: Status of upload
-        enum:
-          - CREATED
-          - UPLOADING
-          - UPLOADED
-          - QUEUED
-          - PROCESSING
-          - COMPLETE
-          - FAILED
-          - ABORTED
-      files:
-        type: array
-        items:
+    allOf:
+    - $ref: '#/definitions/BaseCreate'
+    - type: object
+      properties:
+        uploadStatus:
           type: string
-      uploadType:
-        type: string
-        description: Source of files and uploads
-        enum:
-          - DROPBOX
-          - S3
-          - LOCAL
-      fileType:
-        type: string
-        description: type of data being uploaded, limited to two options right now
-        enum:
-          - GEOTIFF
-          - GEOTIFF_WITH_METADATA
-      datasource:
-        type: string
-        description: datasource of tiffs being uploaded
-        format: uuid
-      visibility:
-        type: string
-        description: Level of restriction on viewing
-        enum:
-          - PUBLIC
-          - ORGANIZATION
-          - PRIVATE
+          description: Status of upload
+          enum:
+            - CREATED
+            - UPLOADING
+            - UPLOADED
+            - QUEUED
+            - PROCESSING
+            - COMPLETE
+            - FAILED
+            - ABORTED
+        files:
+          type: array
+          items:
+            type: string
+          description: An array of strings of file locations. If a source is provided, this can be empty
+        uploadType:
+          type: string
+          description: Source of files and uploads
+          enum:
+            - DROPBOX
+            - S3
+            - LOCAL
+        fileType:
+          type: string
+          description: type of data being uploaded, limited to two options right now
+          enum:
+            - GEOTIFF
+            - GEOTIFF_WITH_METADATA
+        datasource:
+          type: string
+          description: datasource of tiffs being uploaded
+          format: uuid
+        visibility:
+          type: string
+          description: Level of restriction on viewing
+          enum:
+            - PUBLIC
+            - ORGANIZATION
+            - PRIVATE
+        projectId:
+          type: string
+          format: uuid
+          description: during the import process, add scenes to a project if specified
+        source:
+          type: string
+          description: for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored
+        sceneMetadata:
+          $ref: '#/definitions/UploadMetadata'
   Upload:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -2777,6 +2989,15 @@ definitions:
             type: string
         metadata:
           type: object
+  UploadMetadata:
+    type: object
+    properties:
+      sceneCloudCover:
+        type: number
+        format: float32
+      sceneAcquisitionDate:
+        type: string
+        format: datetime
   UploadPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -2892,6 +3113,7 @@ definitions:
   CombinedSceneQueryParams:
     type: object
     description: Combined query parameters for filtering scenes
+    discriminator: type
     properties:
       orgParams:
         $ref: '#/definitions/OrgParams'
@@ -2921,43 +3143,50 @@ definitions:
       $ref: '#/definitions/SceneCorrectionParam'
   ExportCreate:
     type: object
-    properties:
-      projectId:
-        type: string
-        format: uuid
-      sceneIds:
-        type: array
-        items:
+    allOf:
+    - $ref: '#/definitions/BaseCreate'
+    - type: object
+      properties:
+        projectId:
           type: string
           format: uuid
-      exportStatus:
-        type: string
-        description: Status of export
-        enum:
-          - CREATED
-          - EXPORTING
-          - EXPORTED
-          - QUEUED
-          - PROCESSING
-          - COMPLETE
-          - FAILED
-          - ABORTED
-      exportType:
-        type: string
-        description: Source of exports
-        enum:
-          - DROPBOX
-          - S3
-          - LOCAL
-      visibility:
-        type: string
-        description: Level of restriction on viewing
-        enum:
-          - PUBLIC
-          - ORGANIZATION
-          - PRIVATE
-      exportOptions:
-        $ref: '#/definitions/ExportOptions'
+        sceneIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        exportStatus:
+          type: string
+          description: Status of export
+          enum:
+            - CREATED
+            - EXPORTING
+            - EXPORTED
+            - QUEUED
+            - PROCESSING
+            - COMPLETE
+            - FAILED
+            - ABORTED
+        exportType:
+          type: string
+          description: Source of exports
+          enum:
+            - DROPBOX
+            - S3
+            - LOCAL
+        visibility:
+          type: string
+          description: Level of restriction on viewing
+          enum:
+            - PUBLIC
+            - ORGANIZATION
+            - PRIVATE
+        toolRunId:
+          type: string
+          format: uuid
+          description: Optional id of a ToolRun. Specifying this will perform an RDD-AST-based export job.
+        exportOptions:
+          $ref: '#/definitions/ExportOptions'
   Export:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -2990,6 +3219,9 @@ definitions:
     type: object
     description: export params
     properties:
+      operation:
+        type: string
+        description: currently a not supported flag, describes a render operation, "id" by defaut.
       bands:
         type: array
         description: bands in the exported geotiffs
@@ -3010,6 +3242,9 @@ definitions:
       crop:
         type: boolean
         description: crop stitched raster by provided mask if possible
+      raw:
+        type: boolean
+        description: make a raw export skipping all color correction steps
   ExportDefinition:
     type: object
     properties:
@@ -3034,7 +3269,7 @@ definitions:
         format: uuid
       resolution:
         type: integer
-        description: required resolution (currently it's zoom level)
+        description: "required resolution (currently it's zoom level)"
       mask:
         type: object
         description: geojson multipolygon
@@ -3070,6 +3305,9 @@ definitions:
         description: output export path
       render:
         $ref: '#/definitions/Render'
+      dropboxCredential:
+        type: string
+        description: Dropbox token
   Render:
     type: object
     properties:
@@ -3081,3 +3319,13 @@ definitions:
         description: bands in the exported geotiffs
         items:
           type: integer
+
+  BulkAcceptParams:
+    type: object
+    description: bulk accept params
+    properties:
+      sceneIds:
+        type: array
+        items:
+          type: string
+          format: uuid

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -3113,7 +3113,6 @@ definitions:
   CombinedSceneQueryParams:
     type: object
     description: Combined query parameters for filtering scenes
-    discriminator: type
     properties:
       orgParams:
         $ref: '#/definitions/OrgParams'

--- a/rasterfoundry/spec.yml
+++ b/rasterfoundry/spec.yml
@@ -4,7 +4,7 @@ info:
   description: An application to find, view, and analyze geospatial data at any scale
   version: "0.1.0"
 
-host: localhost:9000
+host: app.rasterfoundry.com
 
 schemes:
   - http


### PR DESCRIPTION
Overview
------

This PR pulls over the current swagger spec from the main Raster Foundry repository and updates it it includes post body parameters for `/scenes/` and so bravado doesn't choke on the `discriminator` present in `SceneQueryParameters`.

Testing
------

- `./scripts/update`
- `source venv/bin/activate[.fish]`
- `ipython`, then run:

```python
import uuid
from rasterfoundry.api import API
api = API(<your refresh token>, host=...)
api.client.Imagery.post_scenes(**{'scene': {'organizationId': str(uuid.uuid4())}})
```

The client should complain about normal things like that request being destined for failure, rather than about receiving any parameters at all.
